### PR TITLE
fix: don't load Google Fonts from CDN

### DIFF
--- a/.gatsby/gatsby-config.ts
+++ b/.gatsby/gatsby-config.ts
@@ -73,6 +73,7 @@ module.exports = {
       resolve: `gatsby-plugin-typography`,
       options: {
         pathToConfigModule: `src/utils/typography`,
+        omitGoogleFont: true,
       },
     },
     `gatsby-plugin-typescript`,

--- a/src/utils/typography.ts
+++ b/src/utils/typography.ts
@@ -3,16 +3,6 @@ import Typography from 'typography';
 import { theme } from './theme';
 
 const typography = new Typography({
-  googleFonts: [
-    {
-      name: 'Source Sans Pro',
-      styles: ['400', '600'],
-    },
-    {
-      name: 'Source Code Pro',
-      styles: ['600', '700'],
-    },
-  ],
   baseFontSize: '20px',
   baseLineHeight: 1.85,
   headerColor: theme.colors.grey500,


### PR DESCRIPTION
Background: First of all we had the fonts already included with typeface, but also we are not allowed to send the ip addresses to the google font server (GDPR).