### PR TITLE
fix(google): redirects for /guides and /repos

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,3 +17,11 @@
 [[redirects]]
   from = "/guides/2020-05-02-continuous-integration-with-netlify-build-plugins"
   to = "/2020-05-02-continuous-integration-with-netlify-build-plugins"
+
+[[redirects]]
+  from = "/guides/"
+  to = "/"
+
+[[redirects]]
+  from = "/repos/"
+  to = "/"


### PR DESCRIPTION
The `/guides` and `/repos` pages are still listed on Google Search, so we should provide some redirects. 