### PR TITLE
refactor: improving html elements for blog posts

### DIFF
--- a/src/components/BlogPostActionBar/__snapshots__/BlogPostActionBar.test.tsx.snap
+++ b/src/components/BlogPostActionBar/__snapshots__/BlogPostActionBar.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BlogPostActionBar should match snapshot 1`] = `
 <div>
   <div
-    class="sc-bdfBwQ DorBN sc-gsTCUz cMSAim"
+    class="sc-bdfBwQ cBMwYR sc-gsTCUz cMSAim"
     display="flex"
   >
     <span>

--- a/src/components/BlogPostMetaData/BlogPostMetaData.test.tsx
+++ b/src/components/BlogPostMetaData/BlogPostMetaData.test.tsx
@@ -8,7 +8,12 @@ describe('BlogPostMetaData component', () => {
   it('should render a BlogPostMetaData w/ content', () => {
     const { container } = render(
       <ThemeContext.Provider value={theme}>
-        <BlogPostMetaData date="May 25, 2020" author="Homer Simpson" timeToRead="4" />
+        <BlogPostMetaData
+          date="2020-05-25 15:00:00.000Z"
+          formattedDate="May 25, 2020"
+          author="Homer Simpson"
+          timeToRead="4"
+        />
       </ThemeContext.Provider>
     );
 

--- a/src/components/BlogPostMetaData/BlogPostMetaData.tsx
+++ b/src/components/BlogPostMetaData/BlogPostMetaData.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Typography } from '../Typography/Typography';
 import { useTheme, DefaultTheme } from 'styled-components';
+import { Box } from '../Box/Box';
 
 interface BlogPostMetaDataProps {
-  date: React.ReactNode;
+  date: string;
+  formattedDate: React.ReactNode;
   timeToRead: React.ReactNode;
   author: React.ReactNode;
   mb?: keyof DefaultTheme['space'];
@@ -11,9 +13,10 @@ interface BlogPostMetaDataProps {
 
 export const BlogPostMetaData: React.FC<BlogPostMetaDataProps> = ({
   date,
+  formattedDate,
   timeToRead,
   author,
-  mb = 'l'
+  mb = 'l',
 }) => {
   const theme = useTheme();
   return (
@@ -22,8 +25,17 @@ export const BlogPostMetaData: React.FC<BlogPostMetaDataProps> = ({
       fontFamily="Source Code Pro"
       fontWeight="600"
       mb={theme.space[mb]}
+      as="span"
+      display="block"
     >
-      {date} • {author} • {timeToRead}min read
+      <time dateTime={date}>{formattedDate}</time> •{' '}
+      <Box as="address" display="inline-block">
+        {author}
+      </Box>{' '}
+      •{' '}
+      <Box as="span" display="inline-block">
+        {`${timeToRead}min read`}
+      </Box>
     </Typography>
   );
 };

--- a/src/components/BlogPostMetaData/__snapshots__/BlogPostMetaData.test.tsx.snap
+++ b/src/components/BlogPostMetaData/__snapshots__/BlogPostMetaData.test.tsx.snap
@@ -2,17 +2,34 @@
 
 exports[`BlogPostMetaData component should render a BlogPostMetaData w/ content 1`] = `
 <div>
-  <p
-    class="sc-jSgupP EmhJb"
+  <span
+    class="sc-jSgupP fnsZfl"
+    display="block"
     font-family="Source Code Pro"
     font-weight="600"
   >
-    May 25, 2020
-     • 
-    Homer Simpson
-     • 
-    4
-    min read
-  </p>
+    <time
+      datetime="2020-05-25 15:00:00.000Z"
+    >
+      May 25, 2020
+    </time>
+     •
+     
+    <address
+      class="sc-gKsewC htKuho"
+      display="inline-block"
+    >
+      Homer Simpson
+    </address>
+     
+    •
+     
+    <span
+      class="sc-gKsewC htKuho"
+      display="inline-block"
+    >
+      4min read
+    </span>
+  </span>
 </div>
 `;

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -21,14 +21,22 @@ import {
 } from 'styled-system';
 import { StyledSystemBoxProps } from './types';
 
-type HtmlTags = 'span' | 'aside' | 'main' | 'section' | 'nav' | 'footer' | React.ElementType<any>;
+type HtmlTags =
+  | 'span'
+  | 'aside'
+  | 'main'
+  | 'section'
+  | 'nav'
+  | 'footer'
+  | 'address'
+  | React.ElementType<any>;
 export type BoxProps = StyledSystemBoxProps &
   StyledComponentPropsWithAs<HtmlTags, DefaultTheme, {}, any>;
 
 export const StyledBox = styled.div`
-    box-sizing: border-box;
-    ${color}
-    ${padding}
+  box-sizing: border-box;
+  ${color}
+  ${padding}
     ${margin}
     ${borderRadius}
     ${display}

--- a/src/components/Box/__snapshots__/Box.test.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Box component should render a box w/ content 1`] = `
 <div>
   <div
-    class="sc-bdfBwQ fWxsZr"
+    class="sc-bdfBwQ dvzvdH"
     display="flex"
   >
     <span>

--- a/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Footer should render w/ children 1`] = `
 <div>
   <footer
-    class="sc-bdfBwQ bepFSC"
+    class="sc-bdfBwQ bKXhhG"
     display="flex"
     width="100%"
   >

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -3,20 +3,20 @@
 exports[`List component should render correctly w/ list item 1`] = `
 <div>
   <ul
-    class="sc-bdfBwQ cclmkS"
+    class="sc-bdfBwQ cuenMS"
   >
     <li
-      class="sc-bdfBwQ ivfIwt"
+      class="sc-bdfBwQ jucDrN"
     >
       Hello One
     </li>
     <li
-      class="sc-bdfBwQ ivfIwt"
+      class="sc-bdfBwQ jucDrN"
     >
       Hello Two
     </li>
     <li
-      class="sc-bdfBwQ ivfIwt"
+      class="sc-bdfBwQ jucDrN"
     >
       Hello Hundred
     </li>

--- a/src/components/Teaser/__snapshots__/Teaser.test.tsx.snap
+++ b/src/components/Teaser/__snapshots__/Teaser.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Teaser component should render a teaser w/ content 1`] = `
 <div>
   <div
-    class="sc-bdfBwQ cAWWfp"
+    class="sc-bdfBwQ xXqFh"
     display="flex"
   >
     <span

--- a/src/components/__snapshots__/layout.test.tsx.snap
+++ b/src/components/__snapshots__/layout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Layout renders a header 1`] = `
 <div>
   <div
-    class="sc-fFubgz bTfTvq"
+    class="sc-fFubgz ha-dEYC"
     display="flex"
     height="auto"
     overflow="visible"
@@ -116,7 +116,7 @@ exports[`Layout renders a header 1`] = `
       </button>
     </nav>
     <main
-      class="sc-fFubgz bYPIJD"
+      class="sc-fFubgz jBhBnf"
       width="100%"
     >
       <main>
@@ -126,7 +126,7 @@ exports[`Layout renders a header 1`] = `
       </main>
     </main>
     <footer
-      class="sc-fFubgz hGqBhg"
+      class="sc-fFubgz dqEFCc"
       display="flex"
       width="100%"
     >

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -16,6 +16,11 @@ interface LayoutProps {
 }
 
 const GlobalStyle = createGlobalStyle`
+  address {
+    font-style: normal;
+    margin-bottom: 0;
+  }
+
   ::selection{
     color: white;
     background: ${(props) => props.theme.colors.grey500}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,12 +6,13 @@ import { Navigation } from './Navigation/Navigation';
 import { SocialLink } from './SocialLink/SocialLink';
 import { Twitter } from './SocialLink/Twitter';
 import { Github } from './SocialLink/Github';
-import { Box } from './Box/Box';
+import { Box, BoxProps } from './Box/Box';
 import { MobileNavigationContext } from '../context/MobileNavigationContext/MobileNavigationContext';
 import { Footer } from './Footer/Footer';
 
 interface LayoutProps {
   size?: 'narrow';
+  mainElement?: BoxProps['as'];
 }
 
 const GlobalStyle = createGlobalStyle`
@@ -33,7 +34,11 @@ const GlobalStyle = createGlobalStyle`
   }
 `;
 
-export const Layout: React.FC<LayoutProps> = ({ children, size }) => {
+export const Layout: React.FC<LayoutProps> = ({
+  children,
+  size,
+  mainElement = 'main',
+}) => {
   const theme = useTheme();
 
   const { isMobileNavigationOpen, setIsMobileNavigationOpen } = useContext(
@@ -81,7 +86,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, size }) => {
           </SocialLink>
         </Navigation>
         <Box
-          as="main"
+          as={mainElement}
           width="100%"
           flex="1 0 auto"
           maxWidth={isNarrow ? '680px' : '940px'}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,9 +14,7 @@ const BlogIndex: React.FC = () => {
 
   const data = useStaticQuery<AllGuideBlogPostsQuery>(graphql`
     query allGuideBlogPosts {
-      allMdx(
-        sort: { fields: [frontmatter___date], order: DESC }
-      ) {
+      allMdx(sort: { fields: [frontmatter___date], order: DESC }) {
         nodes {
           excerpt
           timeToRead
@@ -28,7 +26,8 @@ const BlogIndex: React.FC = () => {
           frontmatter {
             title
             description
-            date(formatString: "MMMM DD, YYYY")
+            date
+            formattedDate: date(formatString: "MMMM DD, YYYY")
             author {
               name
             }
@@ -48,7 +47,12 @@ const BlogIndex: React.FC = () => {
         <br /> both Software Developers
         <br /> based in Hamburg.
       </Typography>
-      <Typography variant="subheadline" as="h2" fontWeight="400" mb={theme.space.xxl}>
+      <Typography
+        variant="subheadline"
+        as="h2"
+        fontWeight="400"
+        mb={theme.space.xxl}
+      >
         We would like to help you to stay up to date about the latest
         <br /> trends in web development
       </Typography>
@@ -58,33 +62,35 @@ const BlogIndex: React.FC = () => {
         justifyContent="space-between"
         mb={theme.space.m}
       >
-      {data.allMdx.nodes.map((node) => {
-        const frontmatter = node!.frontmatter!;
-        const excerpt = node!.excerpt!;
-        const description = node!.frontmatter!.description;
-        const date = node!.frontmatter!.date!;
-        const timeToRead = node.timeToRead;
-        const title = frontmatter.title!;
-        const url = `/${node!.parent!.name}/`;
+        {data.allMdx.nodes.map((node) => {
+          const frontmatter = node!.frontmatter!;
+          const excerpt = node!.excerpt!;
+          const description = node!.frontmatter!.description;
+          const date = node!.frontmatter!.date!;
+          const formattedDate = node!.frontmatter!.formattedDate!;
+          const timeToRead = node.timeToRead;
+          const title = frontmatter.title!;
+          const url = `/${node!.parent!.name}/`;
 
-        return (
-          <BlogPostLink
-            url={url}
-            title={title}
-            slug={url}
-            excerpt={description || excerpt}
-            blogType="guide"
-            key={url}
-            metaData={
-              <BlogPostMetaData
-                date={date}
-                timeToRead={timeToRead}
-                author={frontmatter.author.name}
-              />
-            }
-          />
-        );
-      })}
+          return (
+            <BlogPostLink
+              url={url}
+              title={title}
+              slug={url}
+              excerpt={description || excerpt}
+              blogType="guide"
+              key={url}
+              metaData={
+                <BlogPostMetaData
+                  date={date}
+                  formattedDate={formattedDate}
+                  timeToRead={timeToRead}
+                  author={frontmatter.author.name}
+                />
+              }
+            />
+          );
+        })}
       </Box>
     </Layout>
   );

--- a/src/pages/{Mdx.parent__(File)__name}.tsx
+++ b/src/pages/{Mdx.parent__(File)__name}.tsx
@@ -58,6 +58,7 @@ const BlogPost: React.FC<PageProps<BlogPostQuery>> = (props) => {
       </Typography>
       <BlogPostMetaData
         date={frontmatter.date}
+        formattedDate={frontmatter.formattedDate}
         author={frontmatter.author.name}
         timeToRead={post.timeToRead}
         mb="xl"
@@ -95,7 +96,8 @@ export const query = graphql`
       frontmatter {
         title
         description
-        date(formatString: "MMMM DD, YYYY")
+        date
+        formattedDate: date(formatString: "MMMM DD, YYYY")
         author {
           name
           twitter

--- a/src/pages/{Mdx.parent__(File)__name}.tsx
+++ b/src/pages/{Mdx.parent__(File)__name}.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { graphql, PageProps } from 'gatsby'
+import { graphql, PageProps } from 'gatsby';
 import { Layout } from '../components/layout';
 import { SEO, Meta } from '../components/seo';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
@@ -12,7 +12,7 @@ import { BlogPostMetaData } from '../components/BlogPostMetaData/BlogPostMetaDat
 
 const BlogPost: React.FC<PageProps<BlogPostQuery>> = (props) => {
   const theme = useTheme();
-  
+
   const post = props.data.mdx!;
   const excerpt = post.excerpt!;
   const frontmatter = post.frontmatter!;
@@ -31,7 +31,7 @@ const BlogPost: React.FC<PageProps<BlogPostQuery>> = (props) => {
     {
       name: 'twitter:creator',
       content: `@${frontmatter.author.twitter}`,
-    }
+    },
   ];
 
   if (thumbnail) {
@@ -46,14 +46,16 @@ const BlogPost: React.FC<PageProps<BlogPostQuery>> = (props) => {
   }
 
   return (
-    <Layout size="narrow">
+    <Layout size="narrow" mainElement="article">
       <SEO
         title={frontmatter.title!}
         description={description || excerpt}
         meta={meta}
         twitterCard={thumbnail ? 'summary_large_image' : 'summary'}
       />
-      <Typography variant="title" mb={theme.space.xxs}>{post.frontmatter!.title}</Typography>
+      <Typography variant="title" mb={theme.space.xxs}>
+        {post.frontmatter!.title}
+      </Typography>
       <BlogPostMetaData
         date={frontmatter.date}
         author={frontmatter.author.name}
@@ -67,7 +69,7 @@ const BlogPost: React.FC<PageProps<BlogPostQuery>> = (props) => {
   );
 };
 
-export default BlogPost
+export default BlogPost;
 
 export const query = graphql`
   query BlogPost($id: String!) {
@@ -108,4 +110,4 @@ export const query = graphql`
       }
     }
   }
-`
+`;


### PR DESCRIPTION
In order to improve the readability of our blog posts for screen readers, I introduced the `<time>` and `<address>` element as well as wrapping the content with a `<article>` element.